### PR TITLE
30-feat-favorite-events-backend-logic 

### DIFF
--- a/controllers/EventoInteresController.js
+++ b/controllers/EventoInteresController.js
@@ -47,3 +47,10 @@ export const eliminarInteres = asyncHandler(async (req, res) => {
         message: "Interés eliminado exitosamente."
     });
 });
+
+export const obtenerEventosInteresadosPorUsuario = asyncHandler(async (req, res) => {
+    const { usuario_id } = req.params;  
+    const eventos = await eventoInteresService.obtenerEventosInteresadosPorUsuario(usuario_id);
+
+    res.json(eventos);
+});

--- a/routes/EventoInteresRoutes.js
+++ b/routes/EventoInteresRoutes.js
@@ -3,7 +3,8 @@ import {
     registrarInteres, 
     obtenerConteoIntereses,
     isUserInterested,
-    eliminarInteres
+    eliminarInteres,
+    obtenerEventosInteresadosPorUsuario
 } from '../controllers/EventoInteresController.js';
 
 const router = express.Router();
@@ -12,5 +13,6 @@ router.post('/', registrarInteres);
 router.get('/evento/:evento_id/conteo', obtenerConteoIntereses);
 router.get('/evento/:evento_id/verificar/:usuario_id', isUserInterested);
 router.delete('/evento/:evento_id/usuario/:usuario_id', eliminarInteres);
+router.get('/usuario/:usuario_id/eventos', obtenerEventosInteresadosPorUsuario);
 
 export default router;

--- a/services/EventoInteresService.js
+++ b/services/EventoInteresService.js
@@ -46,6 +46,18 @@ class EventoInteresService {
             }
         });
     }
+
+    async obtenerEventosInteresadosPorUsuario(usuario_id) {
+        const intereses = await EventoInteres.findAll({
+            where: { usuario_id },
+            include: {
+                model: Evento,
+                attributes: ['id', 'nombre', 'fecha', 'lugar', 'imagen_url']
+            }
+        });
+
+        return intereses.map(i => i.Evento);
+    }
 }
 
 export default new EventoInteresService();


### PR DESCRIPTION
Adds a new API to fetch events a user is interested in. Implements obtenerEventosInteresadosPorUsuario in the controller, registers GET /usuario/:usuario_id/eventos in the routes, and adds obtenerEventosInteresadosPorUsuario in the service which queries EventoInteres including the related Evento (id, nombre, fecha, lugar, imagen_url) and returns the Evento list. Issue #30 