### PR TITLE
45-refactor-add-atribute-hour-in-response-obtenereventosinteresadosporusuario

### DIFF
--- a/services/EventoInteresService.js
+++ b/services/EventoInteresService.js
@@ -53,7 +53,7 @@ class EventoInteresService {
             where: { usuario_id },
             include: {
                 model: Evento,
-                attributes: ['id', 'nombre', 'fecha', 'hora', 'lugar', 'imagen_url', 'valor'],
+                attributes: ['id', 'nombre', 'fecha', 'hora', 'lugar', 'imagen_url'],
                 include: {
                     model: Ciudad,
                     attributes: ['nombre']


### PR DESCRIPTION
Exclude the 'valor' field from the Evento attributes returned by EventoInteresService, because this field isn't in new Event structure model #45 