### PR TITLE
76-add-unit-test-for-successful-event-creation-in-eventoservice

### DIFF
--- a/tests/eventService.test.js
+++ b/tests/eventService.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import EventoService from '../services/EventoService.js';
+import { Evento } from '../models/Asociaciones.js';
+
+vi.mock('../models/Asociaciones.js', () => ({
+  Evento: {
+    create: vi.fn(),
+  }
+}));
+
+describe('EventoService - createEvent', () => {
+  
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getDate = (daysAhead = 1) => {
+    const date = new Date();
+    date.setDate(date.getDate() + daysAhead);
+    return date.toISOString().split('T')[0];
+  };
+
+  const baseEventData = {
+    nombre: 'Tech Conference 2024',
+    lugar: 'Convention Center',
+    categoria_id: 1,
+    ciudad_id: 5
+  };
+
+  it('should successfully create an event when data and date are valid (Happy Path)', async () => {
+    const validData = { ...baseEventData, fecha: getDate(10) };
+    const mockCreatedEvent = { id: 99, ...validData };
+    
+    Evento.create.mockResolvedValue(mockCreatedEvent);
+
+    const result = await EventoService.crear(validData);
+
+    expect(result).toEqual(mockCreatedEvent);
+    expect(Evento.create).toHaveBeenCalledWith(validData);
+  });
+});


### PR DESCRIPTION
Add a new Vitest unit test file for EventoService.crear. The test mocks Evento.create from models/Asociaciones, provides a getDate helper and baseEventData, clears mocks after each test, and includes a happy-path test that asserts the service calls Evento.create with the expected payload and returns the created event.
Issue #76 